### PR TITLE
Removes dashes from step and job names in Github Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,18 +14,18 @@ on:
 permissions: {}
 
 jobs:
-  download-binaries:
+  downloadbinaries:
     runs-on: ubuntu-latest
     outputs:
       package-version: ${{ steps.package.outputs.package-version }}
-      serverless-compat-version: ${{ steps.serverless-compat-binary.outputs.serverless-compat-version }}
+      serverless-compat-version: ${{ steps.serverlesscompatbinary.outputs.serverless-compat-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: package
         run: |
           PACKAGE_VERSION=$(awk -F '"' '/version = / {print $2}' pyproject.toml)
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
-      - id: serverless-compat-binary
+      - id: serverlesscompatbinary
         run: |
           LIBDATADOG_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/libdatadog/releases")
           SERVERLESS_COMPAT_VERSION=$(echo "$LIBDATADOG_RESPONSE" | jq -r --arg pattern "sls-v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
@@ -45,7 +45,7 @@ jobs:
           path: datadog_serverless_compat/bin
   build:
     runs-on: ubuntu-latest
-    needs: [download-binaries]
+    needs: [downloadbinaries]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -78,12 +78,12 @@ jobs:
   release:
     if: github.event.inputs.publish-destination == 'PyPI'
     runs-on: ubuntu-latest
-    needs: [publish]
+    needs: [downloadbinaries, publish]
     permissions:
       contents: write
     env:
-      PACKAGE_VERSION: ${{ needs.download-binaries.outputs.package-version }}
-      SERVERLESS_COMPAT_VERSION: ${{ needs.download-binaries.outputs.serverless-compat-version }}
+      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
+      SERVERLESS_COMPAT_VERSION: ${{ needs.downloadbinaries.outputs.serverless-compat-version }}
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:


### PR DESCRIPTION
### What does this PR do?

Removes dashes from step and job names in Github Action to publish PyPI package.

### Motivation

Outputs from one job failed to be passed as environment variables to the release job.

### Additional Notes

Release job relies on upstream jobs to be created with the correct version tags.

### Describe how to test/QA your changes

Created test branch to run Github Action on and confirm release is created with correct version tags.
