### PR TITLE
Pass serverless compat version to binary via environment variable

### DIFF
--- a/datadog_serverless_compat/main.py
+++ b/datadog_serverless_compat/main.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from importlib.metadata import PackageNotFoundError, version
 import logging
 import os
 from subprocess import Popen
@@ -56,6 +57,18 @@ def get_binary_path():
     return binary_path
 
 
+# Pass package version to binary via environment variable
+def set_package_version():
+    try:
+        package_version = version("datadog-serverless-compat")
+    except PackageNotFoundError as err:
+        logger.error(f"Unable to identify package version: {err}")
+        package_version = "unknown"
+
+    logger.debug(f"Setting DD_SERVERLESS_COMPAT_VERSION to {package_version}")
+    os.environ["DD_SERVERLESS_COMPAT_VERSION"] = package_version
+
+
 def start():
     environment = get_environment()
     logger.debug(f"Environment detected: {environment}")
@@ -85,6 +98,8 @@ def start():
             f"Serverless Compatibility Layer did not start, could not find binary at path {binary_path}"
         )
         return
+
+    set_package_version()
 
     try:
         logger.debug(

--- a/datadog_serverless_compat/main.py
+++ b/datadog_serverless_compat/main.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 import logging
 import os
 from subprocess import Popen
@@ -61,8 +61,8 @@ def get_binary_path():
 def set_package_version():
     try:
         package_version = version("datadog-serverless-compat")
-    except PackageNotFoundError as err:
-        logger.error(f"Unable to identify package version: {err}")
+    except Exception as e:
+        logger.error(f"Unable to identify package version: {e}")
         package_version = "unknown"
 
     logger.debug(f"Setting DD_SERVERLESS_COMPAT_VERSION to {package_version}")


### PR DESCRIPTION
### What does this PR do?

Set `DD_SERVERLESS_COMPAT_VERSION` to the currently installed package version.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6326

### Additional Notes

Previously the version was set to the binary version. Since these packages were introduced it would be useful for troubleshooting to track the versions installed by users. Since a specific version of the binary is packaged in each package version we can still trace back the binary version via the package version.

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
