### PR TITLE
chore: use binaries from serverless-components in release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,18 @@ name: Publish packages on PyPI
 on:
   workflow_dispatch:
     inputs:
-      publish-destination:
+      publish-package:
+        description: "Build or Build and Publish?"
+        required: true
         type: choice
-        description: Publish to PyPI or TestPyPI?
+        default: "Build"
+        options:
+          - "Build"
+          - "Build and Publish"
+      publish-destination:
+        description: "Publish to PyPI or TestPyPI?"
+        required: true
+        type: choice
         default: "TestPyPI"
         options:
           - "TestPyPI"
@@ -27,18 +36,14 @@ jobs:
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverlesscompatbinary
         run: |
-          LIBDATADOG_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/libdatadog/releases")
-          SERVERLESS_COMPAT_VERSION=$(echo "$LIBDATADOG_RESPONSE" | jq -r --arg pattern "sls-v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
+          RESPONSE=$(curl -s "https://api.github.com/repos/datadog/serverless-components/releases")
+          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
 
           echo "Using version ${SERVERLESS_COMPAT_VERSION} of Serverless Compatibility Layer binary"
           echo "serverless-compat-version=$(echo "$SERVERLESS_COMPAT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
 
-          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/libdatadog/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-agent.zip"
-          unzip ./temp/datadog-serverless-agent.zip -d ./temp/datadog-serverless-agent
-
-          mkdir -p datadog_serverless_compat/bin/linux-amd64 datadog_serverless_compat/bin/windows-amd64
-          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-linux-amd64/datadog-serverless-trace-mini-agent datadog_serverless_compat/bin/linux-amd64/datadog-serverless-compat
-          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-windows-amd64/datadog-serverless-trace-mini-agent.exe datadog_serverless_compat/bin/windows-amd64/datadog-serverless-compat.exe
+          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/serverless-components/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-compat.zip"
+          unzip ./temp/datadog-serverless-compat.zip -d ./datadog_serverless_compat
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: bin
@@ -66,6 +71,7 @@ jobs:
           name: dist
           path: dist
   publish:
+    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -76,7 +82,7 @@ jobs:
           password: ${{ github.event.inputs.publish-destination == 'PyPI' && secrets.PYPI_SERVERLESS_COMPAT_API_TOKEN || secrets.PYPI_SERVERLESS_COMPAT_API_TOKEN_TEST }}
           repository-url: ${{ github.event.inputs.publish-destination == 'PyPI' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
   release:
-    if: github.event.inputs.publish-destination == 'PyPI'
+    if: ${{ github.event.inputs.publish-package == 'Build and Publish' && github.event.inputs.publish-destination == 'PyPI' }}
     runs-on: ubuntu-latest
     needs: [downloadbinaries, publish]
     permissions:


### PR DESCRIPTION
### What does this PR do?

- Use binaries from serverless-components in package
- Add option to only build (and not publish) package for testing

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6786

### Additional Notes

### Describe how to test/QA your changes

Published to test PyPI and deployed to Azure Functions
