### PR TITLE
chore: refactor package version and fix serverless-components link in release note

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
-          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/libdatadog/releases/tag/sls-${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
+          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
           draft: true
           tag_name: "v${{ env.PACKAGE_VERSION }}"
           generate_release_notes: true

--- a/datadog_serverless_compat/main.py
+++ b/datadog_serverless_compat/main.py
@@ -57,16 +57,14 @@ def get_binary_path():
     return binary_path
 
 
-# Pass package version to binary via environment variable
-def set_package_version():
+def get_package_version():
     try:
         package_version = version("datadog-serverless-compat")
     except Exception as e:
         logger.error(f"Unable to identify package version: {e}")
         package_version = "unknown"
 
-    logger.debug(f"Setting DD_SERVERLESS_COMPAT_VERSION to {package_version}")
-    os.environ["DD_SERVERLESS_COMPAT_VERSION"] = package_version
+    return package_version
 
 
 def start():
@@ -99,13 +97,16 @@ def start():
         )
         return
 
-    set_package_version()
+    package_version = get_package_version()
+    logger.debug(f"Found package version {package_version}")
 
     try:
         logger.debug(
             f"Trying to spawn the Serverless Compatibility Layer at path: {binary_path}"
         )
-        Popen(binary_path)
+        env = os.environ.copy()
+        env["DD_SERVERLESS_COMPAT_VERSION"] = package_version
+        Popen(binary_path, env=env)
     except Exception as e:
         logger.error(
             f"An unexpected error occurred while spawning Serverless Compatibility Layer process: {repr(e)}"


### PR DESCRIPTION
### What does this PR do?

* rename package version method
* Only set `DD_SERVERLESS_COMPAT_VERSION` environment variable on subprocess
* fix serverless-components link in release note 

### Motivation

* get package version method naming consistency with other Serverless Compatibility Layer packages
* Avoid setting environment variables on main process that aren't needed
* Link correctly to serverless-components repo in release note

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Deployed to Azure Functions, validated that `_dd.serverless_compat_version` attribute is set correctly
