### PR TITLE
fix: copy binary to temp directory and set execute permissions at startup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,9 +56,6 @@ jobs:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: datadog_serverless_compat
-      - run: |
-          chmod +x datadog_serverless_compat/bin/linux-amd64/datadog-serverless-compat
-          chmod +x datadog_serverless_compat/bin/windows-amd64/datadog-serverless-compat.exe
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.9 - 3.12"


### PR DESCRIPTION
### What does this PR do?

Copy `datadog-serverless-compat` binary to a temp directory and set execute permissions at startup.

### Motivation

Depending on the deployment method the execute permissions can be stripped from the binary. This ensures that the binary has execute permissions regardless of the deployment method.

https://datadoghq.atlassian.net/browse/SVLS-6768

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Deployed package to the environments below with binaries stripped of execute permissions and confirmed that the binary still starts and traces are sent to Datadog. ssh'ed into environments where possible to verify file correctly had execute permissions added (Azure Function PremiumV3 environments).

Tested both a fresh install and an upgrade from the latest version to this development version.

- Azure Function / Linux / PremiumV3 ✅ 
- Azure Function / Linux / Consumption ✅ 
- Azure Function / Linux / Flex ✅ 
- Google Cloud Run Function Gen 1 
