### PR TITLE
chore: use poetry version to set package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,12 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: package
         run: |
-          PACKAGE_VERSION=$(awk -F '"' '/version = / {print $2}' pyproject.toml)
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
+
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverlesscompatbinary
         run: |
@@ -51,6 +56,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [downloadbinaries]
+    env:
+      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -65,6 +72,7 @@ jobs:
       - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: 1.8.5
+      - run: poetry version ${{ env.PACKAGE_VERSION }}
       - run: poetry build
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datadog-serverless-compat"
-version = "0.4.0"
+version = "0.0.0"
 description = "Datadog Serverless Compatibility Layer for Python"
 authors = ["Datadog, Inc. <dev@datadoghq.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### What does this PR do?

Use `poetry version` in Github release workflow to set the version instead of hardcoding the version in `poetry.toml`.

### Motivation

Remove a manual step during the release process.

### Additional Notes

Package version is read from the Git tag used for the release.

### Describe how to test/QA your changes

Tested in a separate repo to avoid the creation of test tags and test releases in this repo.

- Validated that packages created during the build step have a version which matches the tag the Github workflow ran against
- Validated that the workflow stops if the tag does not match the expected format `vMAJOR.MINOR.PATCH`
